### PR TITLE
install health check via go get no longer works

### DIFF
--- a/mainnet-v1history/nodeos/Dockerfile
+++ b/mainnet-v1history/nodeos/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:latest AS health
 
-RUN go get github.com/blockpane/fio-docker/health
+RUN go install github.com/blockpane/fio-docker/health@latest
 
 FROM ubuntu:18.04
 

--- a/mainnet/nodeos/Dockerfile
+++ b/mainnet/nodeos/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:latest AS health
 
-RUN go get github.com/blockpane/fio-docker/health
+RUN go install github.com/blockpane/fio-docker/health@latest
 
 FROM ubuntu:18.04
 

--- a/testnet-v1history/nodeos/Dockerfile
+++ b/testnet-v1history/nodeos/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:latest AS health
 
-RUN go get github.com/blockpane/fio-docker/health
+RUN go install github.com/blockpane/fio-docker/health@latest
 
 FROM ubuntu:18.04
 

--- a/testnet/nodeos/Dockerfile
+++ b/testnet/nodeos/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:latest AS health
 
-RUN go get github.com/blockpane/fio-docker/health
+RUN go install github.com/blockpane/fio-docker/health@latest
 
 FROM ubuntu:18.04
 


### PR DESCRIPTION
Pull in latest change from Blockpane repo.